### PR TITLE
Send a KeyboardInterrupt 60s before job finish

### DIFF
--- a/docs/computing/atomate.md
+++ b/docs/computing/atomate.md
@@ -167,6 +167,7 @@ nodes: 1
 walltime: '24:00:00'
 account: matgen
 job_name: knl_launcher
+signal: SIGINT@60
 qos: regular
 constraint: 'knl'
 pre_rocket: |


### PR DESCRIPTION
Adding this line (recommended by Shyam) to my_qadapter will cause Cori to send a KeyboardInterrupt 60s before your job runs out of wall time. This will generally result in better error reporting and may prevent 'lost runs'.