### PR TITLE
Add warning for redirect to Gitbook

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,11 @@
+!!! warning
+
+    The Persson Group Handbook has __moved__ locations as of Fall 2021. Please see our new page below:
+    
+    [**https://materialsproject.gitbook.io/persson-group-handbook/**](https://materialsproject.gitbook.io/persson-group-handbook/)
+    
+    This outdated version of the handbook will remain available for some time before being phased out in 2022.
+
 # The Persson Group Handbook
 
 This website serves as the group handbook for the [Persson Group](http://perssongroup.lbl.gov) at the University of California, Berkeley / Lawrence Berkeley National Laboratory. The purpose of this handbook is to provide information to new students and post-docs who do not yet have full access to internal group resources when they first join the group (hence why this handbook is publically available). This handbook is just the starting point to ensure a smoother integration of new group members and an efficient onboarding process.
@@ -7,6 +15,5 @@ Our newest group members often have the most valuable insight in improving the
   the Onboarding Guides have ultimate responsibility of overseeing the handbook (see
    [group jobs](about/group_jobs.md)), all Persson Group members are encouraged to
     contribute to this handbook via the [open-source repo.](https://github.com/perssongroup/handbook)
-
 
 ![Persson Group Photo](resources/Persson_Group_Image.jpg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,9 @@ markdown_extensions:
       single_block_as_tab: False
       active_class: 'active'
       template: 'default'
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
 
 extra_css:
   - 'css/code-tabs.css'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,8 +36,6 @@ markdown_extensions:
       active_class: 'active'
       template: 'default'
   - admonition
-  - pymdownx.details
-  - pymdownx.superfences
 
 extra_css:
   - 'css/code-tabs.css'


### PR DESCRIPTION
We need to phase out this old handbook site. I added a redirect to the Gitbook page.